### PR TITLE
Also clean old DAGs

### DIFF
--- a/db-cleanup/airflow-db-cleanup.py
+++ b/db-cleanup/airflow-db-cleanup.py
@@ -1,4 +1,4 @@
-from airflow.models import DAG, DagRun, TaskInstance, Log, XCom, SlaMiss
+from airflow.models import DAG, DagRun, TaskInstance, Log, XCom, SlaMiss, DagModel
 from airflow.jobs import BaseJob
 from airflow.models import settings
 from airflow.operators import PythonOperator
@@ -30,6 +30,7 @@ DATABASE_OBJECTS = [                    # List of all the objects that will be d
     {"airflow_db_model": XCom, "age_check_column": XCom.execution_date},
     {"airflow_db_model": BaseJob, "age_check_column": BaseJob.latest_heartbeat},
     {"airflow_db_model": SlaMiss, "age_check_column": SlaMiss.execution_date},
+    {"airflow_db_model": DagModel, "age_check_column": DagModel.last_scheduler_run},
 ]
 
 session = settings.Session()


### PR DESCRIPTION
Hello

We are versionning DAG names as is suggested by some Airflow best-practises. So we end up having a lot of staled DAG laying around in the web interface.
To get rid of them, we need to suppress them, otherwise Airflow keeps to think them active.

What do you think about this change ?