### PR TITLE
Updated airflow db cleanup with time aware datetimes

### DIFF
--- a/db-cleanup/airflow-db-cleanup.py
+++ b/db-cleanup/airflow-db-cleanup.py
@@ -5,6 +5,7 @@ from airflow.operators import PythonOperator
 from datetime import datetime, timedelta
 import os
 import logging
+import pytz
 
 """
 A maintenance workflow that you can deploy into Airflow to periodically clean out the DagRun, TaskInstance, Log, XCom, Job DB and SlaMiss entries to avoid having too much data in your Airflow MetaStore.
@@ -17,7 +18,7 @@ airflow trigger_dag --conf '{"maxDBEntryAgeInDays":30}' airflow-db-cleanup
 """
 
 DAG_ID = os.path.basename(__file__).replace(".pyc", "").replace(".py", "")  # airflow-db-cleanup
-START_DATE = datetime.now() - timedelta(minutes=1)
+START_DATE = pytz.utc.localize(datetime.now() - timedelta(minutes=1))
 SCHEDULE_INTERVAL = "@daily"            # How often to Run. @daily - Once a day at Midnight (UTC)
 DAG_OWNER_NAME = "operations"           # Who is listed as the owner of this DAG in the Airflow Web Server
 ALERT_EMAIL_ADDRESSES = []              # List of email address to send email alerts to if this job fails
@@ -59,7 +60,7 @@ def print_configuration_function(**context):
     if max_db_entry_age_in_days is None:
         logging.info("maxDBEntryAgeInDays conf variable isn't included. Using Default '" + str(DEFAULT_MAX_DB_ENTRY_AGE_IN_DAYS) + "'")
         max_db_entry_age_in_days = DEFAULT_MAX_DB_ENTRY_AGE_IN_DAYS
-    max_date = datetime.now() + timedelta(-max_db_entry_age_in_days)
+    max_date = pytz.utc.localize(datetime.now() + timedelta(-max_db_entry_age_in_days))
     logging.info("Finished Loading Configurations")
     logging.info("")
 


### PR DESCRIPTION
Due to recent updates in sqlalchemy (1.1.18) and airflow (1.10.0), I was getting error about naive datetimes (caused due to timezone not being known). Just making the start date and max date timezone aware solves the issue.