### PR TITLE
Change imports due to deprecation in Airflow 1.10

### DIFF
--- a/db-cleanup/airflow-db-cleanup.py
+++ b/db-cleanup/airflow-db-cleanup.py
@@ -1,7 +1,7 @@
 from airflow.models import DAG, DagRun, TaskInstance, Log, XCom, SlaMiss, DagModel, Variable
 from airflow.jobs import BaseJob
 from airflow.models import settings
-from airflow.operators import PythonOperator
+from airflow.operators.python_operator import PythonOperator
 from datetime import datetime, timedelta
 import os
 import logging

--- a/kill-halted-tasks/airflow-kill-halted-tasks.py
+++ b/kill-halted-tasks/airflow-kill-halted-tasks.py
@@ -1,5 +1,6 @@
 from airflow.models import DAG, DagModel, DagRun, TaskInstance, settings
-from airflow.operators import PythonOperator, ShortCircuitOperator, EmailOperator
+from airflow.operators.python_operator import PythonOperator, ShortCircuitOperator
+from airflow.operators.email_operator import EmailOperator
 from sqlalchemy import and_
 from datetime import datetime, timedelta
 import os

--- a/log-cleanup/airflow-log-cleanup.py
+++ b/log-cleanup/airflow-log-cleanup.py
@@ -1,5 +1,5 @@
 from airflow.models import DAG, Variable
-from airflow.operators import BashOperator
+from airflow.operators.bash_operator import BashOperator
 from airflow.configuration import conf
 from datetime import datetime, timedelta
 import os
@@ -84,5 +84,4 @@ for log_cleanup_id in range(1, NUMBER_OF_WORKERS + 1):
     log_cleanup = BashOperator(
         task_id='log_cleanup_' + str(log_cleanup_id),
         bash_command=log_cleanup,
-        provide_context=True,
         dag=dag)


### PR DESCRIPTION
Airflow marked imports from airflow.operators as deprecated.