### PR TITLE
[feature] datetime object backwards compatibility and bugfix session complete

### DIFF
--- a/db-cleanup/airflow-db-cleanup.py
+++ b/db-cleanup/airflow-db-cleanup.py
@@ -5,6 +5,11 @@ from airflow.operators import PythonOperator
 from datetime import datetime, timedelta
 import os
 import logging
+try:
+    from airflow.utils import timezone  
+    now = timezone.utcnow
+except ImportError:
+    now = datetime.now 
 
 """
 A maintenance workflow that you can deploy into Airflow to periodically clean out the DagRun, TaskInstance, Log, XCom, Job DB and SlaMiss entries to avoid having too much data in your Airflow MetaStore.
@@ -17,7 +22,7 @@ airflow trigger_dag --conf '{"maxDBEntryAgeInDays":30}' airflow-db-cleanup
 """
 
 DAG_ID = os.path.basename(__file__).replace(".pyc", "").replace(".py", "")  # airflow-db-cleanup
-START_DATE = datetime.now() - timedelta(minutes=1)
+START_DATE = now() - timedelta(minutes=1)
 SCHEDULE_INTERVAL = "@daily"            # How often to Run. @daily - Once a day at Midnight (UTC)
 DAG_OWNER_NAME = "operations"           # Who is listed as the owner of this DAG in the Airflow Web Server
 ALERT_EMAIL_ADDRESSES = []              # List of email address to send email alerts to if this job fails
@@ -59,7 +64,7 @@ def print_configuration_function(**context):
     if max_db_entry_age_in_days is None:
         logging.info("maxDBEntryAgeInDays conf variable isn't included. Using Default '" + str(DEFAULT_MAX_DB_ENTRY_AGE_IN_DAYS) + "'")
         max_db_entry_age_in_days = DEFAULT_MAX_DB_ENTRY_AGE_IN_DAYS
-    max_date = datetime.now() + timedelta(-max_db_entry_age_in_days)
+    max_date = now() + timedelta(-max_db_entry_age_in_days)
     logging.info("Finished Loading Configurations")
     logging.info("")
 

--- a/db-cleanup/airflow-db-cleanup.py
+++ b/db-cleanup/airflow-db-cleanup.py
@@ -115,6 +115,8 @@ def cleanup_function(**context):
         logging.info("Performing Delete...")
         for entry in entries_to_delete:
             session.delete(entry)
+        session.commit()
+        session.close()        
         logging.info("Finished Performing Delete")
     else:
         logging.warn("You're opted to skip deleting the db entries!!!")

--- a/db-cleanup/airflow-db-cleanup.py
+++ b/db-cleanup/airflow-db-cleanup.py
@@ -9,7 +9,7 @@ try:
     from airflow.utils import timezone  
     now = timezone.utcnow
 except ImportError:
-    now = datetime.now 
+    now = datetime.utcnow 
 
 """
 A maintenance workflow that you can deploy into Airflow to periodically clean out the DagRun, TaskInstance, Log, XCom, Job DB and SlaMiss entries to avoid having too much data in your Airflow MetaStore.


### PR DESCRIPTION
Airflow store metadata with utc time datetime object, with timezone in airflow 1.10.
