### PR TITLE
Timezone aware datetime for airflow 1.10.0

### DIFF
--- a/db-cleanup/airflow-db-cleanup.py
+++ b/db-cleanup/airflow-db-cleanup.py
@@ -5,6 +5,7 @@ from airflow.operators import PythonOperator
 from datetime import datetime, timedelta
 import os
 import logging
+import pytz
 
 """
 A maintenance workflow that you can deploy into Airflow to periodically clean out the DagRun, TaskInstance, Log, XCom, Job DB and SlaMiss entries to avoid having too much data in your Airflow MetaStore.
@@ -59,7 +60,7 @@ def print_configuration_function(**context):
     if max_db_entry_age_in_days is None:
         logging.info("maxDBEntryAgeInDays conf variable isn't included. Using Default '" + str(DEFAULT_MAX_DB_ENTRY_AGE_IN_DAYS) + "'")
         max_db_entry_age_in_days = DEFAULT_MAX_DB_ENTRY_AGE_IN_DAYS
-    max_date = datetime.now() + timedelta(-max_db_entry_age_in_days)
+    max_date = datetime.now(pytz.utc) + timedelta(-max_db_entry_age_in_days)
     logging.info("Finished Loading Configurations")
     logging.info("")
 


### PR DESCRIPTION
Previous version fails in airflow 1.10.0 because it's timezone aware now rather than just assuming UTC for everything.

Log fragment:
[2018-10-17 17:03:04,891] {models.py:1736} ERROR - (builtins.ValueError) naive datetime is disallowed [SQL: 'SELECT dag_run.state AS dag_run_state, dag_run.id AS dag_run_id, dag_run.dag_id AS dag_run_dag_id, dag_run.execution_date AS dag_run_execution_date, dag_run.start_date AS dag_run_start_date, dag_run.end_date AS dag_run_end_date, dag_run.run_id AS dag_run_run_id, dag_run.external_trigger AS dag_run_external_trigger, dag_run.conf AS dag_run_conf \nFROM dag_run \nWHERE dag_run.execution_date <= %(execution_date_1)s'] [parameters: [{}]]
Traceback (most recent call last):
  File "/usr/lib/airflow/lib/python3.6/site-packages/sqlalchemy/engine/base.py", line 1116, in _execute_context
    context = constructor(dialect, self, conn, *args)
  File "/usr/lib/airflow/lib/python3.6/site-packages/sqlalchemy/engine/default.py", line 649, in _init_compiled
    for key in compiled_params
  File "/usr/lib/airflow/lib/python3.6/site-packages/sqlalchemy/engine/default.py", line 649, in <genexpr>
    for key in compiled_params
  File "/usr/lib/airflow/lib/python3.6/site-packages/sqlalchemy/sql/type_api.py", line 1078, in process
    return process_param(value, dialect)
  File "/usr/lib/airflow/lib/python3.6/site-packages/airflow/utils/sqlalchemy.py", line 156, in process_bind_param
    raise ValueError('naive datetime is disallowed')
ValueError: naive datetime is disallowed

The above exception was the direct cause of the following exception: