### PR TITLE
Fix variable assignment bug in airflow-log-cleanup

### DIFF
--- a/log-cleanup/airflow-log-cleanup.py
+++ b/log-cleanup/airflow-log-cleanup.py
@@ -79,10 +79,11 @@ fi
 echo "Finished Running Cleanup Process"
 """
 
+cleanup_tasks = {}
 for log_cleanup_id in range(1, NUMBER_OF_WORKERS + 1):
-
-    log_cleanup = BashOperator(
-        task_id='log_cleanup_' + str(log_cleanup_id),
+    task_id = 'log_cleanup_' + str(log_cleanup_id)
+    cleanup_tasks[task_id] = BashOperator(
+        task_id=task_id,
         bash_command=log_cleanup,
         provide_context=True,
         dag=dag)


### PR DESCRIPTION
This error occurs when tasks are ran on > 1 workers:
```bash
[2018-10-25 10:52:38,722] {base_task_runner.py:107} INFO - Job 753876: Subtask log_cleanup_spark /usr/local/lib/python2.7/site-packages/airflow/utils/helpers.py:346: DeprecationWarning: Importing 'HttpHook' directly from 'airflow.hooks' has been deprecated. Please import from 'airflow.hooks.[operator_module]' instead. Support for direct imports will be dropped entirely in Airflow 2.0.
[2018-10-25 10:52:38,722] {base_task_runner.py:107} INFO - Job 753876: Subtask log_cleanup_spark   DeprecationWarning)
[2018-10-25 10:52:39,031] {base_task_runner.py:107} INFO - Job 753876: Subtask log_cleanup_spark [2018-10-25 10:52:39,031] {__init__.py:51} INFO - Using executor CeleryExecutor
[2018-10-25 10:52:39,147] {base_task_runner.py:107} INFO - Job 753876: Subtask log_cleanup_spark [2018-10-25 10:52:39,146] {models.py:258} INFO - Filling up the DagBag from /mnt/storage/airflow/scripts/airflow/adhoc_dags/airflow-log-cleanup.py
[2018-10-25 10:52:39,150] {base_task_runner.py:107} INFO - Job 753876: Subtask log_cleanup_spark /usr/local/lib/python2.7/site-packages/airflow/utils/helpers.py:346: DeprecationWarning: Importing 'BashOperator' directly from 'airflow.operators' has been deprecated. Please import from 'airflow.operators.[operator_module]' instead. Support for direct imports will be dropped entirely in Airflow 2.0.
[2018-10-25 10:52:39,150] {base_task_runner.py:107} INFO - Job 753876: Subtask log_cleanup_spark   DeprecationWarning)
[2018-10-25 10:52:39,274] {base_task_runner.py:107} INFO - Job 753876: Subtask log_cleanup_spark [2018-10-25 10:52:39,274] {cli.py:492} INFO - Running <TaskInstance: airflow-log-cleanup.log_cleanup_spark 2018-10-25T10:50:01.861032+00:00 [running]> on host airflow-adhoc-sparkworker-deployment-1.airflow-adhoc-sparkworker-service.adhoc.svc.cluster.local
[2018-10-25 10:52:39,329] {models.py:1736} ERROR - Type '<class 'bash_operator.BashOperator'>' used for parameter 'bash_command' is not supported for templating
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/airflow/models.py", line 1618, in _run_raw_task
    self.render_templates()
  File "/usr/local/lib/python2.7/site-packages/airflow/models.py", line 1927, in render_templates
    rendered_content = rt(attr, content, jinja_context)
  File "/usr/local/lib/python2.7/site-packages/airflow/models.py", line 2763, in render_template
    return self.render_template_from_field(attr, content, context, jinja_env)
  File "/usr/local/lib/python2.7/site-packages/airflow/models.py", line 2745, in render_template_from_field
    raise AirflowException(msg)
AirflowException: Type '<class 'bash_operator.BashOperator'>' used for parameter 'bash_command' is not supported for templating
```