### PR TITLE
Airflow DB Cleanup script fixes

### DIFF
--- a/db-cleanup/airflow-db-cleanup.py
+++ b/db-cleanup/airflow-db-cleanup.py
@@ -15,7 +15,7 @@ from datetime import datetime, timedelta
 import os
 import logging
 try:
-    from airflow.utils import timezone
+    from airflow.utils import timezone #airflow.utils.timezone is available from v1.10 onwards
     now = timezone.utcnow
 except ImportError:
     now = datetime.utcnow

--- a/kill-halted-tasks/airflow-kill-halted-tasks.py
+++ b/kill-halted-tasks/airflow-kill-halted-tasks.py
@@ -1,5 +1,7 @@
 from airflow.models import DAG, DagModel, DagRun, TaskInstance, settings
-from airflow.operators import PythonOperator, ShortCircuitOperator, EmailOperator
+from airflow.operators.email_operator import EmailOperator
+from airflow.operators.python_operator import PythonOperator
+from airflow.operators.python_operator import ShortCircuitOperator
 from sqlalchemy import and_
 from datetime import datetime, timedelta
 import os

--- a/kill-halted-tasks/airflow-kill-halted-tasks.py
+++ b/kill-halted-tasks/airflow-kill-halted-tasks.py
@@ -1,3 +1,11 @@
+"""
+A maintenance workflow that you can deploy into Airflow to periodically kill off tasks that are running in the background that don't correspond to a running task in the DB.
+
+This is useful because when you kill off a DAG Run or Task through the Airflow Web Server, the task still runs in the background on one of the executors until the task is complete.
+
+airflow trigger_dag airflow-kill-halted-tasks
+
+"""
 from airflow.models import DAG, DagModel, DagRun, TaskInstance, settings
 from airflow.operators.python_operator import PythonOperator, ShortCircuitOperator
 from airflow.operators.email_operator import EmailOperator
@@ -7,14 +15,6 @@ import os
 import re
 import logging
 from pytz import timezone
-"""
-A maintenance workflow that you can deploy into Airflow to periodically kill off tasks that are running in the background that don't correspond to a running task in the DB.
-
-This is useful because when you kill off a DAG Run or Task through the Airflow Web Server, the task still runs in the background on one of the executors until the task is complete.
-
-airflow trigger_dag airflow-kill-halted-tasks
-
-"""
 
 DAG_ID = os.path.basename(__file__).replace(".pyc", "").replace(".py", "")  # airflow-kill-halted-tasks
 START_DATE = datetime.now() - timedelta(minutes=1)
@@ -38,6 +38,7 @@ default_args = {
 }
 
 dag = DAG(DAG_ID, default_args=default_args, schedule_interval=SCHEDULE_INTERVAL, start_date=START_DATE)
+dag.doc_md = __doc__
 
 uid_regex = "(\w+)"
 pid_regex = "(\w+)"

--- a/log-cleanup/airflow-log-cleanup.py
+++ b/log-cleanup/airflow-log-cleanup.py
@@ -12,9 +12,15 @@ from airflow.configuration import conf
 from airflow.operators.bash_operator import BashOperator
 from datetime import datetime, timedelta
 import os
+try:
+    from airflow.utils import timezone #airflow.utils.timezone is available from v1.10 onwards
+    now = timezone.utcnow
+except ImportError:
+    now = datetime.utcnow
+
 
 DAG_ID = os.path.basename(__file__).replace(".pyc", "").replace(".py", "")  # airflow-log-cleanup
-START_DATE = datetime.now() - timedelta(minutes=1)
+START_DATE = now() - timedelta(minutes=1)
 BASE_LOG_FOLDER = conf.get("core", "BASE_LOG_FOLDER")
 SCHEDULE_INTERVAL = "@daily"        # How often to Run. @daily - Once a day at Midnight
 DAG_OWNER_NAME = "operations"       # Who is listed as the owner of this DAG in the Airflow Web Server

--- a/log-cleanup/airflow-log-cleanup.py
+++ b/log-cleanup/airflow-log-cleanup.py
@@ -1,6 +1,6 @@
 from airflow.models import DAG, Variable
-from airflow.operators import BashOperator
 from airflow.configuration import conf
+from airflow.operators.bash_operator import BashOperator
 from datetime import datetime, timedelta
 import os
 

--- a/log-cleanup/airflow-log-cleanup.py
+++ b/log-cleanup/airflow-log-cleanup.py
@@ -1,9 +1,3 @@
-from airflow.models import DAG, Variable
-from airflow.configuration import conf
-from airflow.operators.bash_operator import BashOperator
-from datetime import datetime, timedelta
-import os
-
 """
 A maintenance workflow that you can deploy into Airflow to periodically clean out the task logs to avoid those getting too big.
 
@@ -13,6 +7,11 @@ airflow trigger_dag --conf '{"maxLogAgeInDays":30}' airflow-log-cleanup
     maxLogAgeInDays:<INT> - Optional
 
 """
+from airflow.models import DAG, Variable
+from airflow.configuration import conf
+from airflow.operators.bash_operator import BashOperator
+from datetime import datetime, timedelta
+import os
 
 DAG_ID = os.path.basename(__file__).replace(".pyc", "").replace(".py", "")  # airflow-log-cleanup
 START_DATE = datetime.now() - timedelta(minutes=1)
@@ -35,6 +34,7 @@ default_args = {
 }
 
 dag = DAG(DAG_ID, default_args=default_args, schedule_interval=SCHEDULE_INTERVAL, start_date=START_DATE)
+dag.doc_md = __doc__
 
 log_cleanup = """
 echo "Getting Configurations..."

--- a/log-cleanup/airflow-log-cleanup.py
+++ b/log-cleanup/airflow-log-cleanup.py
@@ -81,7 +81,7 @@ echo "Finished Running Cleanup Process"
 
 for log_cleanup_id in range(1, NUMBER_OF_WORKERS + 1):
 
-    log_cleanup = BashOperator(
+    log_cleanup_op = BashOperator(
         task_id='log_cleanup_' + str(log_cleanup_id),
         bash_command=log_cleanup,
         provide_context=True,


### PR DESCRIPTION
Fixed following issues
1.Added session.commit() after delete for airflow 1.9
2.Change imports due to deprecation in Airflow 1.10
3.ERROR - naive datetime is disallowed
4.'max_db_entry_age_in_days' from Variable causes a TypeError: bad operand type for unary -: 'str'