### PR TITLE
Use '-exec rm' in find cmd to delete files/dirs

### DIFF
--- a/log-cleanup/airflow-log-cleanup.py
+++ b/log-cleanup/airflow-log-cleanup.py
@@ -82,7 +82,7 @@ then
     DELETE_STMT="${FIND_STATEMENT} -exec rm -f {} \;"
 else
     FIND_STATEMENT="find ${BASE_LOG_FOLDER}/*/* -type d -empty"
-    DELETE_STMT="${FIND_STATEMENT} -exec rm -rf {} \;"
+    DELETE_STMT="${FIND_STATEMENT} -prune -exec rm -rf {} \;"
 fi
 echo "Executing Find Statement: ${FIND_STATEMENT}"
 FILES_MARKED_FOR_DELETE=`eval ${FIND_STATEMENT}`

--- a/log-cleanup/airflow-log-cleanup.py
+++ b/log-cleanup/airflow-log-cleanup.py
@@ -79,8 +79,10 @@ echo "Running Cleanup Process..."
 if [ $TYPE == file ];
 then
     FIND_STATEMENT="find ${BASE_LOG_FOLDER}/*/* -type f -mtime +${MAX_LOG_AGE_IN_DAYS}"
+    DELETE_STMT="${FIND_STATEMENT} -exec rm -f {} \;"
 else
     FIND_STATEMENT="find ${BASE_LOG_FOLDER}/*/* -type d -empty"
+    DELETE_STMT="${FIND_STATEMENT} -exec rm -rf {} \;"
 fi
 echo "Executing Find Statement: ${FIND_STATEMENT}"
 FILES_MARKED_FOR_DELETE=`eval ${FIND_STATEMENT}`
@@ -92,7 +94,6 @@ if [ "${ENABLE_DELETE}" == "true" ];
 then
     if [ "${FILES_MARKED_FOR_DELETE}" != "" ];
     then
-        DELETE_STMT="rm -r `echo "${FILES_MARKED_FOR_DELETE}" | tr '\n' ' '`"
         echo "Executing Delete Statement: ${DELETE_STMT}"
         eval ${DELETE_STMT}
         DELETE_STMT_EXIT_CODE=$?


### PR DESCRIPTION
When there are many files/directories to cleanup you might face: `/bin/rm: cannot execute [Argument list too long]`

This pull request eliminates that problem by using the `--exec rm` together with the find command.