### PR TITLE
fix invalid exception syntax

### DIFF
--- a/clear-missing-dags/airflow-clear-missing-dags.py
+++ b/clear-missing-dags/airflow-clear-missing-dags.py
@@ -47,7 +47,7 @@ def clear_missing_dags_fn(**context):
         host_ip = socket.gethostbyname(host_name)
         logging.info("Running on Machine with Host Name: " + host_name)
         logging.info("Running on Machine with IP: " + host_ip)
-    except Exception, e:
+    except Exception as e:
         print("Unable to get Host Name and IP: " + str(e))
 
     session = settings.Session()


### PR DESCRIPTION
Fixes invalid python syntax in `airflow-clear-missing-dags.py` on line 50.

![Screenshot 2019-09-16 at 15 35 28](https://user-images.githubusercontent.com/7973166/64967079-d6fbd380-d897-11e9-947e-685276741121.png)
