### PR TITLE
Fix Boolean error in DagRun db-cleanup (postgresql)

### DIFF
--- a/db-cleanup/airflow-db-cleanup.py
+++ b/db-cleanup/airflow-db-cleanup.py
@@ -33,7 +33,7 @@ ALERT_EMAIL_ADDRESSES = []              # List of email address to send email al
 DEFAULT_MAX_DB_ENTRY_AGE_IN_DAYS = int(Variable.get("airflow_db_cleanup__max_db_entry_age_in_days", 30)) # Length to retain the log files if not already provided in the conf. If this is set to 30, the job will remove those files that are 30 days old or older.
 ENABLE_DELETE = True                    # Whether the job should delete the db entries or not. Included if you want to temporarily avoid deleting the db entries.
 DATABASE_OBJECTS = [                    # List of all the objects that will be deleted. Comment out the DB objects you want to skip.
-    {"airflow_db_model": DagRun, "age_check_column": DagRun.execution_date, "keep_last": True, "keep_last_filters": [DagRun.external_trigger==0], "keep_last_group_by": DagRun.dag_id},
+    {"airflow_db_model": DagRun, "age_check_column": DagRun.execution_date, "keep_last": True, "keep_last_filters": [DagRun.external_trigger==False], "keep_last_group_by": DagRun.dag_id},
     {"airflow_db_model": TaskInstance, "age_check_column": TaskInstance.execution_date, "keep_last": False, "keep_last_filters": None, "keep_last_group_by": None},
     {"airflow_db_model": Log, "age_check_column": Log.dttm, "keep_last": False, "keep_last_filters": None, "keep_last_group_by": None},
     {"airflow_db_model": XCom, "age_check_column": XCom.execution_date, "keep_last": False, "keep_last_filters": None, "keep_last_group_by": None},


### PR DESCRIPTION
Fix error
sqlalchemy.exc.ProgrammingError: (psycopg2.errors.UndefinedFunction) operator does not exist: **boolean = integer**
LINE 6: WHERE **dag_run.external_trigger = 0** GROUP BY dag_run.dag_id) ...