### PR TITLE
Add directory id to task_id to avoid task dependency duplication

### DIFF
--- a/log-cleanup/airflow-log-cleanup.py
+++ b/log-cleanup/airflow-log-cleanup.py
@@ -210,10 +210,10 @@ fi
 
 for log_cleanup_id in range(1, NUMBER_OF_WORKERS + 1):
 
-    for directory in DIRECTORIES_TO_DELETE:
+    for dir_id, directory in enumerate(DIRECTORIES_TO_DELETE):
 
         log_cleanup_op = BashOperator(
-            task_id='log_cleanup_worker_num_' + str(log_cleanup_id),
+            task_id='log_cleanup_worker_num_' + str(log_cleanup_id) + '_dir_' + str(dir_id),
             bash_command=log_cleanup,
             params={
                 "directory": str(directory),


### PR DESCRIPTION
If there are more than one items in `DIRECTORIES_TO_DELETE`, the `dependency <task_id, start>` would be registered more than one time during Airflow DAG rendering process, which raises the error.

My solution is to make `task_id` distinct for different directories to delete.

