### PR TITLE
[FIX] rendered_task_instance not available in airflow 1.10.9

### DIFF
--- a/db-cleanup/airflow-db-cleanup.py
+++ b/db-cleanup/airflow-db-cleanup.py
@@ -17,7 +17,6 @@ from airflow.jobs import BaseJob
 from airflow.operators.python_operator import PythonOperator
 from datetime import datetime, timedelta
 import dateutil.parser
-import importlib
 import logging
 import os
 from sqlalchemy import func, and_

--- a/db-cleanup/airflow-db-cleanup.py
+++ b/db-cleanup/airflow-db-cleanup.py
@@ -10,7 +10,6 @@ airflow trigger_dag --conf '[curly-braces]"maxDBEntryAgeInDays":30[curly-braces]
 
 """
 import airflow
-import importlib
 from airflow import settings
 from airflow.configuration import conf
 from airflow.models import DAG, DagRun, Variable
@@ -18,6 +17,7 @@ from airflow.jobs import BaseJob
 from airflow.operators.python_operator import PythonOperator
 from datetime import datetime, timedelta
 import dateutil.parser
+import importlib
 import logging
 import os
 from sqlalchemy import func, and_

--- a/db-cleanup/airflow-db-cleanup.py
+++ b/db-cleanup/airflow-db-cleanup.py
@@ -14,7 +14,7 @@ from airflow import settings
 from airflow.configuration import conf
 from airflow.jobs import BaseJob
 from airflow.models import DAG, DagRun, TaskInstance, Log, XCom, SlaMiss, \
-    DagModel, Variable, TaskReschedule, TaskFail, RenderedTaskInstanceFields
+    DagModel, Variable, TaskReschedule, TaskFail
 from airflow.models.errors import ImportError
 from airflow.operators.python_operator import PythonOperator
 from datetime import datetime, timedelta
@@ -125,14 +125,23 @@ DATABASE_OBJECTS = [
         "keep_last_filters": None,
         "keep_last_group_by": None
     },
-    {
+]
+
+
+def versiontuple(v):
+    return tuple(map(int, (v.split("."))))
+
+
+if (versiontuple(str(airflow.__version__)) > versiontuple("1.10.9")):
+    from airflow.models import RenderedTaskInstanceFields
+    DATABASE_OBJECTS.append({
         "airflow_db_model": RenderedTaskInstanceFields,
         "age_check_column": RenderedTaskInstanceFields.execution_date,
         "keep_last": False,
         "keep_last_filters": None,
         "keep_last_group_by": None
-    }
-]
+    })
+
 
 # Check for celery executor
 airflow_executor = str(conf.get("core", "executor"))
@@ -147,7 +156,7 @@ if(airflow_executor == "CeleryExecutor"):
         "keep_last_filters": None,
         "keep_last_group_by": None
     },
-    {
+        {
         "airflow_db_model": TaskSet,
         "age_check_column": TaskSet.date_done,
         "keep_last": False,

--- a/db-cleanup/airflow-db-cleanup.py
+++ b/db-cleanup/airflow-db-cleanup.py
@@ -156,7 +156,7 @@ if(airflow_executor == "CeleryExecutor"):
         "keep_last_filters": None,
         "keep_last_group_by": None
     },
-        {
+    {
         "airflow_db_model": TaskSet,
         "age_check_column": TaskSet.date_done,
         "keep_last": False,

--- a/db-cleanup/airflow-db-cleanup.py
+++ b/db-cleanup/airflow-db-cleanup.py
@@ -106,7 +106,6 @@ DATABASE_OBJECTS = [
 # Check for TaskReschedule model
 try:
     from airflow.models import TaskReschedule
-
     DATABASE_OBJECTS.append({
         "airflow_db_model": TaskReschedule,
         "age_check_column": TaskReschedule.execution_date,
@@ -121,7 +120,6 @@ except Exception as e:
 # Check for TaskFail model
 try:
     from airflow.models import TaskFail
-
     DATABASE_OBJECTS.append({
         "airflow_db_model": TaskFail,
         "age_check_column": TaskFail.execution_date,
@@ -136,7 +134,6 @@ except Exception as e:
 # Check for RenderedTaskInstanceFields model
 try:
     from airflow.models import RenderedTaskInstanceFields
-
     DATABASE_OBJECTS.append({
         "airflow_db_model": RenderedTaskInstanceFields,
         "age_check_column": RenderedTaskInstanceFields.execution_date,
@@ -151,7 +148,6 @@ except Exception as e:
 # Check for ImportError model
 try:
     from airflow.models import ImportError
-
     DATABASE_OBJECTS.append({
         "airflow_db_model": ImportError,
         "age_check_column": ImportError.timestamp,

--- a/db-cleanup/airflow-db-cleanup.py
+++ b/db-cleanup/airflow-db-cleanup.py
@@ -67,7 +67,6 @@ DATABASE_OBJECTS = [{
      "keep_last_group_by": None
      }]
 
-
 MODEL_OBJECTS = [
     {
         "airflow_db_model": "TaskInstance",
@@ -156,20 +155,21 @@ logging.info("Airflow Executor: " + str(airflow_executor))
 if(airflow_executor == "CeleryExecutor"):
     logging.info("Including Celery Modules")
     from celery.backends.database.models import Task, TaskSet
-    DATABASE_OBJECTS.extend(({
-        "airflow_db_model": Task,
-        "age_check_column": Task.date_done,
-        "keep_last": False,
-        "keep_last_filters": None,
-        "keep_last_group_by": None
-    },
+    DATABASE_OBJECTS.extend((
         {
-        "airflow_db_model": TaskSet,
-        "age_check_column": TaskSet.date_done,
-        "keep_last": False,
-        "keep_last_filters": None,
-        "keep_last_group_by": None
-    }))
+            "airflow_db_model": Task,
+            "age_check_column": Task.date_done,
+            "keep_last": False,
+            "keep_last_filters": None,
+            "keep_last_group_by": None
+        },
+        {
+            "airflow_db_model": TaskSet,
+            "age_check_column": TaskSet.date_done,
+            "keep_last": False,
+            "keep_last_filters": None,
+            "keep_last_group_by": None
+        }))
 
 session = settings.Session()
 


### PR DESCRIPTION
[FIX] rendered_task_instance not available in airflow 1.10.9; conducting a version check now and adding that model if airflow version is greater than 1.10.9
