### PR TITLE
Fix Keep Last Logic

### DIFF
--- a/db-cleanup/airflow-db-cleanup.py
+++ b/db-cleanup/airflow-db-cleanup.py
@@ -64,7 +64,7 @@ DATABASE_OBJECTS = [
         "airflow_db_model": DagRun,
         "age_check_column": DagRun.execution_date,
         "keep_last": True,
-        "keep_last_filters": [DagRun.external_trigger is False],
+        "keep_last_filters": [DagRun.external_trigger.is_(False)],
         "keep_last_group_by": DagRun.dag_id
     },
     {


### PR DESCRIPTION
It appears commit a5fc73b introduced a bug by specifying a `keep_last_filters` of `[DagRun.external_trigger is False]`. This Python expression evaluates to `False` which then causes the subquery filter clause here:
https://github.com/teamclairvoyant/airflow-maintenance-dags/blob/master/db-cleanup/airflow-db-cleanup.py#L295-L296

To basically execute `subquery = subquery.filter(False)` which translates into the SQL predicate `WHERE false = 1` for the subquery and making it impossible for the latest record to be selected and stopping it from being deleted. With this patch applied the predicate becomes `WHERE dag_run.external_trigger IS false` which I think is the intended action for this code.