### PR TITLE
fix(log-cleanup): Argument list too long

### DIFF
--- a/log-cleanup/airflow-log-cleanup.py
+++ b/log-cleanup/airflow-log-cleanup.py
@@ -175,20 +175,23 @@ if [ ! -f """ + str(LOG_CLEANUP_PROCESS_LOCK_FILE) + """ ]; then
     echo ""
     echo "Running Cleanup Process..."
 
-    FIND_STATEMENT="find ${BASE_LOG_FOLDER}/*/* -type f -mtime \
+    # Delete log files
+    FIND_STATEMENT="find ${BASE_LOG_FOLDER} -type f -mtime \
      +${MAX_LOG_AGE_IN_DAYS}"
     DELETE_STMT="${FIND_STATEMENT} -exec rm -f {} \;"
 
     cleanup "${FIND_STATEMENT}" "${DELETE_STMT}"
     CLEANUP_EXIT_CODE=$?
 
-    FIND_STATEMENT="find ${BASE_LOG_FOLDER}/*/* -type d -empty"
+    # Delete empty DAG run folders
+    FIND_STATEMENT="find ${BASE_LOG_FOLDER} -type d -empty"
     DELETE_STMT="${FIND_STATEMENT} -prune -exec rm -rf {} \;"
 
     cleanup "${FIND_STATEMENT}" "${DELETE_STMT}"
     CLEANUP_EXIT_CODE=$?
 
-    FIND_STATEMENT="find ${BASE_LOG_FOLDER}/* -type d -empty"
+    # Delete empty DAG folders
+    FIND_STATEMENT="find ${BASE_LOG_FOLDER} -type d -empty"
     DELETE_STMT="${FIND_STATEMENT} -prune -exec rm -rf {} \;"
 
     cleanup "${FIND_STATEMENT}" "${DELETE_STMT}"


### PR DESCRIPTION
Airflow instances with a lot of DAG runs create lots of small log files.
The `find` command is able to search for patterns, iterating over and
deleting them. However, the old way would use the shell's globbing
feature and pass the directories to check for as individual arguments.
This can cause an "Argument list too long" error.

![MicrosoftTeams-image](https://github.com/teamclairvoyant/airflow-maintenance-dags/assets/31095474/78440847-109a-4796-adf9-647fd6c273e5)

